### PR TITLE
restore kit counts and replace city with delivery options for restaurants

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,23 +1,6 @@
 {
   "short_name": "Cookit",
   "name": "Cookit - Home Cooked, Restaurant Quality",
-  "icons": [
-    {
-      "src": "",
-      "sizes": "64x64 32x32 24x24 16x16",
-      "type": "image/x-icon"
-    },
-    {
-      "src": "",
-      "type": "image/png",
-      "sizes": "192x192"
-    },
-    {
-      "src": "",
-      "type": "image/png",
-      "sizes": "512x512"
-    }
-  ],
   "start_url": ".",
   "display": "standalone",
   "theme_color": "#000000",

--- a/src/components/KitItem.js
+++ b/src/components/KitItem.js
@@ -52,13 +52,13 @@ export default function KitItem({ kit }) {
 
 KitItem.propTypes = {
   kit: PropTypes.shape({
-    id: PropTypes.string.isRequired,
+    id: PropTypes.number.isRequired,
     name: PropTypes.string.isRequired,
-    photos: PropTypes.arrayOf(),
-    price: PropTypes.string.isRequired,
+    photos: PropTypes.arrayOf(PropTypes.object),
+    price: PropTypes.number.isRequired,
     restaurant: PropTypes.shape({
       name: PropTypes.string.isRequired,
-      tags: PropTypes.arrayOf().isRequired,
+      tags: PropTypes.arrayOf(PropTypes.object).isRequired,
     }).isRequired,
   }).isRequired,
 };

--- a/src/components/Price.js
+++ b/src/components/Price.js
@@ -3,7 +3,6 @@ import { makeStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 import PropTypes from 'prop-types';
 
-
 const useStyles = makeStyles({
   root: {
     fontWeight: 600,
@@ -12,14 +11,9 @@ const useStyles = makeStyles({
 
 export default function Hook({ price }) {
   const classes = useStyles();
-  return (
-    <Typography className={classes.root}>
-      £
-      {price}
-    </Typography>
-);
+  return <Typography className={classes.root}>£{price}</Typography>;
 }
 
 Hook.propTypes = {
-  price: PropTypes.string.isRequired,
-}
+  price: PropTypes.number.isRequired,
+};

--- a/src/components/RestaurantItem.js
+++ b/src/components/RestaurantItem.js
@@ -7,7 +7,6 @@ import { makeStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 import React from 'react';
 import PropTypes from 'prop-types';
-// import Price from './Price';
 
 const useStyles = makeStyles({
   root: {
@@ -24,7 +23,9 @@ const useStyles = makeStyles({
 
 export default function RestaurantItem({ restaurant }) {
   const classes = useStyles();
-  const { id, photos, name, city, tags, kits } = restaurant;
+  const deliveryOptions = restaurant.delivery_options;
+  const kitCount = restaurant.kit_count;
+  const { id, photos, name, tags } = restaurant;
 
   return (
     <Card elevation={3} key={id} className={classes.root}>
@@ -32,7 +33,8 @@ export default function RestaurantItem({ restaurant }) {
         <CardMedia
           className={classes.media}
           image={photos[0].service_url}
-          title="Contemplative Reptile"
+          title={name}
+          alt={name}
         />
         {tags.map((tag) => (
           <Chip key={tag.id} label={tag.name} variant="outlined" m={1} />
@@ -42,13 +44,12 @@ export default function RestaurantItem({ restaurant }) {
             {name}
           </Typography>
           <Typography variant="body2" color="textSecondary" component="p" gutterBottom>
-            {city}
+            {deliveryOptions}
           </Typography>
-          {/* <Typography variant="body2" color="textSecondary" component="p" gutterBottom>
-            {kits.length > 1 ? `${kits.length} kits ` : `${kits.length} kit `}
+          <Typography variant="body2" color="textSecondary" component="p" gutterBottom>
+            {kitCount > 1 ? `${kitCount} kits ` : `${kitCount} kit `}
             available
-          </Typography> */}
-          {/* <Price price={restaurant.price}/> */}
+          </Typography>
         </CardContent>
       </CardActionArea>
     </Card>
@@ -57,11 +58,11 @@ export default function RestaurantItem({ restaurant }) {
 
 RestaurantItem.propTypes = {
   restaurant: PropTypes.shape({
-    id: PropTypes.string.isRequired,
+    id: PropTypes.number.isRequired,
     name: PropTypes.string.isRequired,
-    photos: PropTypes.arrayOf(),
-    city: PropTypes.string.isRequired,
-    tags: PropTypes.arrayOf().isRequired,
-    kits: PropTypes.arrayOf().isRequired,
+    photos: PropTypes.arrayOf(PropTypes.object),
+    delivery_options: PropTypes.string.isRequired,
+    tags: PropTypes.arrayOf(PropTypes.object).isRequired,
+    kit_count: PropTypes.number.isRequired,
   }).isRequired,
 };

--- a/src/libraries/KitLibrary.js
+++ b/src/libraries/KitLibrary.js
@@ -21,12 +21,7 @@ class KitLibrary extends Component {
     const { kits } = this.state;
     return (
       <div>
-        <Grid
-          container
-          spacing={4}
-          alignItems="center"
-          justify="space-around"
-        >
+        <Grid container spacing={2} alignItems="center" justify="space-around">
           {kits.map((kit) => (
             <Grid item key={kit.id} xs={12} sm={6} md={4} lg={3} xl={3} zeroMinWidth>
               <KitItem key={kit.id} kit={kit} />

--- a/src/libraries/RestaurantLibrary.js
+++ b/src/libraries/RestaurantLibrary.js
@@ -22,7 +22,7 @@ class RestaurantLibrary extends Component {
     const { restaurants } = this.state;
     return (
       <Box>
-        <Grid container spacing={4} alignItems="center" justify="space-around">
+        <Grid container spacing={2} alignItems="center" justify="space-around">
           {restaurants.map((restaurant) => (
             <Grid item key={restaurant.id} xs={12} sm={6} md={4} lg={3} xl={3} zeroMinWidth>
               <RestaurantItem key={restaurant.id} restaurant={restaurant} />


### PR DESCRIPTION
- used the new kit_counts attribute to restore the kit count feature on restaurant cards
- replaced the restaurant city with delivery options (makes more sense to show this)