### PR TITLE
replace images with unsplash for dev

### DIFF
--- a/src/components/KitItem.js
+++ b/src/components/KitItem.js
@@ -42,7 +42,12 @@ export default function KitItem({ element }) {
     <Card elevation={3} key={id} className={classes.root}>
       <Link to={`/kit/${id}`} className={classes.link}>
         <CardActionArea>
-          <CardMedia className={classes.media} image={photos[0].service_url} title={name} />
+          {/* <CardMedia className={classes.media} image={photos[0].service_url} title={name} /> */}
+          <CardMedia
+            className={classes.media}
+            image="https://source.unsplash.com/800x450/?food,dish"
+            title={name}
+          />
           {restaurant.tags.map((tag) => (
             <Chip key={tag.id} label={tag.name} variant="outlined" margin="1rem" />
           ))}

--- a/src/components/RestaurantItem.js
+++ b/src/components/RestaurantItem.js
@@ -38,9 +38,15 @@ export default function RestaurantItem({ element }) {
     <Card elevation={3} key={id} className={classes.root}>
       <Link to={`/restaurant/${id}`} className={classes.link}>
         <CardActionArea>
-          <CardMedia
+          {/* <CardMedia
             className={classes.media}
             image={photos[0].service_url}
+            title={name}
+            alt={name}
+          /> */}
+          <CardMedia
+            className={classes.media}
+            image="https://source.unsplash.com/800x450/?restaurant"
             title={name}
             alt={name}
           />

--- a/src/pages/Kit.js
+++ b/src/pages/Kit.js
@@ -116,10 +116,15 @@ const Kit = ({ id }) => {
               <Grid container>
                 <Grid item className={classes.image}>
                   <Image
-                    src={data.photos[0].service_url}
+                    src="https://source.unsplash.com/800x450/?food,dish"
                     alt={data.name}
                     imageStyle={{ margin: '8px', height: '400px', objectFit: 'cover' }}
                   />
+                  {/* <Image
+                    src={data.photos[0].service_url}
+                    alt={data.name}
+                    imageStyle={{ margin: '8px', height: '400px', objectFit: 'cover' }}
+                  /> */}
                 </Grid>
               </Grid>
               <Grid container className={classes.tabContainer}>


### PR DESCRIPTION
- commented out AWS image components from kit item, restaurant item and kit show components
- replaced with duplicate components sourcing image from unsplash
- images will all be the same unfortunately as it makes the call once each for kit and restaurant